### PR TITLE
Vector Representation in FBDs

### DIFF
--- a/src/pages/sta/free_body_diagrams.astro
+++ b/src/pages/sta/free_body_diagrams.astro
@@ -75,15 +75,15 @@ import Example from "../../components/Example.astro"
   <p>
     Many problems involve setting up a free body diagram with assumed directions for unknown forces or moments.
     <li>When solving for the magnitude of vectors with assumed directions, if the value is found to be negative, it means that the direction of that vector is the opposite of what was assumed.</li>
-    <li>The negative output says nothing about the signs of x, y, or z-components of the vector, only that the direction is the opposite of what was assumed in the free body diagram setup.</li>
+    <li>The negative output says nothing about the signs of x, y, or z-components of the vector, only that the direction of the entire vector is the opposite of what was assumed in the free body diagram setup.</li>
   </p>
-  <CalloutContainer slot="cards">
-    <CalloutCard title="Heads up!">
+  <CalloutContainer slot = "cards">
+    <CalloutCard title = "Heads up!">
       <p>
-        <strong><a href = "/sta/reaction_forces#types_of_connections">Types of connections</a></strong> and <strong><a href = "/sta/trusses#assumptions">truss assumptions</a></strong> build on this content later in the course.
+        <strong><a href = "/sta/reaction_forces#types_of_connections">Types of connections</a></strong> and <strong><a href = "/sta/trusses#assumptions">truss assumptions</a></strong> builds on this content later in the course.
       </p>
-</CalloutCard>
-</CalloutContainer>
+    </CalloutCard>
+  </CalloutContainer>
 </SubSection>
 
 <SubSection title="Pulley idealizations" id="pulley_idealizations">

--- a/src/pages/sta/free_body_diagrams.astro
+++ b/src/pages/sta/free_body_diagrams.astro
@@ -11,7 +11,6 @@ import PrairieDrawCanvas from "../../components/PrairieDrawCanvas.astro"
 import CalloutContainer from "../../components/CalloutContainer.astro"
 import CalloutCard from "../../components/CalloutCard.astro"
 import DisplayTable from "../../components/DisplayTable.astro"
-import Example from "../../components/Example.astro"
 ---
 <Layout title = "Free body diagrams" description = "Learn how to represent the external forces on a system graphically.">
 

--- a/src/pages/sta/free_body_diagrams.astro
+++ b/src/pages/sta/free_body_diagrams.astro
@@ -11,6 +11,7 @@ import PrairieDrawCanvas from "../../components/PrairieDrawCanvas.astro"
 import CalloutContainer from "../../components/CalloutContainer.astro"
 import CalloutCard from "../../components/CalloutCard.astro"
 import DisplayTable from "../../components/DisplayTable.astro"
+import Example from "../../components/Example.astro"
 ---
 <Layout title = "Free body diagrams" description = "Learn how to represent the external forces on a system graphically.">
 
@@ -70,7 +71,20 @@ import DisplayTable from "../../components/DisplayTable.astro"
 
 </Section>
 
-<SubSection title = "Vector representation in FBDs" id = "vector_representation_in_fbds"/>
+<SubSection title = "Vector representation in FBDs" id = "vector_representation_in_fbds">
+  <p>
+    Many problems involve setting up a free body diagram with assumed directions for unknown forces or moments.
+    <li>When solving for the magnitude of vectors with assumed directions, if the value is found to be negative, it means that the direction of that vector is the opposite of what was assumed.</li>
+    <li>The negative output says nothing about the signs of x, y, or z-components of the vector, only that the direction is the opposite of what was assumed in the free body diagram setup.</li>
+  </p>
+  <CalloutContainer slot="cards">
+    <CalloutCard title="Heads up!">
+      <p>
+        <strong><a href = "/sta/reaction_forces#types_of_connections">Types of connections</a></strong> and <strong><a href = "/sta/trusses#assumptions">truss assumptions</a></strong> build on this content later in the course.
+      </p>
+</CalloutCard>
+</CalloutContainer>
+</SubSection>
 
 <SubSection title="Pulley idealizations" id="pulley_idealizations">
 

--- a/src/pages/sta/free_body_diagrams.astro
+++ b/src/pages/sta/free_body_diagrams.astro
@@ -73,7 +73,7 @@ import Warning from "../../components/Warning.astro"
   <CalloutContainer slot = "cards">
     <CalloutCard title = "Heads up!">
       <p>
-        <strong><a href = "/sta/trusses#assumptions">truss assumptions</a></strong> builds on this content later in the course.
+        <strong><a href = "/sta/trusses#assumptions">Truss assumptions</a></strong> builds on this content later in the course.
       </p>
     </CalloutCard>
   </CalloutContainer>

--- a/src/pages/sta/free_body_diagrams.astro
+++ b/src/pages/sta/free_body_diagrams.astro
@@ -79,7 +79,7 @@ import DisplayTable from "../../components/DisplayTable.astro"
   <CalloutContainer slot = "cards">
     <CalloutCard title = "Heads up!">
       <p>
-        <strong><a href = "/sta/reaction_forces#types_of_connections">Types of connections</a></strong> and <strong><a href = "/sta/trusses#assumptions">truss assumptions</a></strong> builds on this content later in the course.
+        <strong><a href = "/sta/trusses#assumptions">truss assumptions</a></strong> builds on this content later in the course.
       </p>
     </CalloutCard>
   </CalloutContainer>

--- a/src/pages/sta/free_body_diagrams.astro
+++ b/src/pages/sta/free_body_diagrams.astro
@@ -11,6 +11,7 @@ import PrairieDrawCanvas from "../../components/PrairieDrawCanvas.astro"
 import CalloutContainer from "../../components/CalloutContainer.astro"
 import CalloutCard from "../../components/CalloutCard.astro"
 import DisplayTable from "../../components/DisplayTable.astro"
+import Warning from "../../components/Warning.astro"
 ---
 <Layout title = "Free body diagrams" description = "Learn how to represent the external forces on a system graphically.">
 
@@ -49,33 +50,26 @@ import DisplayTable from "../../components/DisplayTable.astro"
 		<li> Kinematic quantities (velocity and acceleration). </li>
 	</ul>
 
-<CalloutContainer slot="cards">
-        <CalloutCard title="Warning!">
-            <p>
-                Always assume the direction of forces/moments to be positive according to the appropriate coordinate system. The calculations from Newton/Euler equations will provide you with the correct direction of those forces/moments. Things that should not follow this are:
-              </p>
-              <ul>
-                <li> Gravity </li>
-				<li> Tension </li>
-				<li> Friction if the velocity <InlineEquation equation="\\vec{v}" /> is provided </li>
-              </ul>
-        </CalloutCard>
-        <CalloutCard title="Warning!">
-            <p>
-                If forces/moments are present, always begin with a free-body diagram. Do not write down equations before drawing the FBD as those are often simple kinematic equations, or Newton/Euler equations.
-              </p>
-        </CalloutCard>
-    </CalloutContainer>
+  <Warning title = "Always assume the direction of forces/moments to be positive according to the appropriate coordinate system." id = "warning1">
+    <p>
+      The calculations from Newton/Euler equations will provide you with the correct direction of those forces/moments. Things that should not follow this are:
+    </p>
+    <ul>
+        <li>Gravity</li>
+        <li>Tension</li>
+				<li>Friction if the velocity <InlineEquation equation = "\\vec{v}" /> is provided</li>
+    </ul>
+  </Warning>
+  <Warning title = "If forces/moments are present, always begin with a free-body diagram." id = "warning2">
+    <p>
+      Do not write down equations before drawing the FBD as those are often simple kinematic equations, or Newton/Euler equations.
+    </p>
+  </Warning>
 
 
 </Section>
 
 <SubSection title = "Vector representation in FBDs" id = "vector_representation_in_fbds">
-  <p>
-    Many problems involve setting up a free body diagram with assumed directions for unknown forces or moments.
-    <li>When solving for the magnitude of vectors with assumed directions, if the value is found to be negative, it means that the direction of that vector is the opposite of what was assumed.</li>
-    <li>The negative output says nothing about the signs of x, y, or z-components of the vector, only that the direction of the entire vector is the opposite of what was assumed in the free body diagram setup.</li>
-  </p>
   <CalloutContainer slot = "cards">
     <CalloutCard title = "Heads up!">
       <p>
@@ -83,6 +77,11 @@ import DisplayTable from "../../components/DisplayTable.astro"
       </p>
     </CalloutCard>
   </CalloutContainer>
+  <p>
+    Many problems involve setting up a free body diagram with assumed directions for unknown forces or moments.
+    <li>When solving for the magnitude of vectors with assumed directions, if the value is found to be negative, it means that the direction of that vector is the opposite of what was assumed.</li>
+    <li>The negative output says nothing about the signs of x, y, or z-components of the vector, only that the direction of the entire vector is the opposite of what was assumed in the free body diagram setup.</li>
+  </p>
 </SubSection>
 
 <SubSection title="Pulley idealizations" id="pulley_idealizations">

--- a/src/pages/sta/reaction_forces.astro
+++ b/src/pages/sta/reaction_forces.astro
@@ -69,14 +69,6 @@ A roller support only constrains movement in the y-direction, and thus only has 
 			You can learn more about the Krannert Center for the Performing Arts <a target = "_blank" rel = "noopener noreferrer" href = "https://krannertcenter.com/events/krannert-center-tours">here.</a>
 		</p>
 	</CalloutCard>
-	<CalloutCard title = "Review?">
-		<p>
-			Need a review of <strong>types of connections?</strong>
-		</p>
-		<p>
-			This content has also been explained <a href = "/sta/free_body_diagrams#vector_representation_in_fbds">earlier in the course</a>
-		</p>
-	</CalloutCard>
 </CalloutContainer>
 
 </SubSection>

--- a/src/pages/sta/reaction_forces.astro
+++ b/src/pages/sta/reaction_forces.astro
@@ -69,6 +69,14 @@ A roller support only constrains movement in the y-direction, and thus only has 
 			You can learn more about the Krannert Center for the Performing Arts <a target = "_blank" rel = "noopener noreferrer" href = "https://krannertcenter.com/events/krannert-center-tours">here.</a>
 		</p>
 	</CalloutCard>
+	<CalloutCard title = "Review?">
+		<p>
+			Need a review of <strong>types of connections?</strong>
+		</p>
+		<p>
+			This content has also been explained <a href = "/sta/free_body_diagrams#vector_representation_in_fbds">earlier in the course</a>
+		</p>
+	</CalloutCard>
 </CalloutContainer>
 
 </SubSection>

--- a/src/pages/sta/trusses.astro
+++ b/src/pages/sta/trusses.astro
@@ -12,6 +12,8 @@ import InlineEquation from "../../components/InlineEquation.astro"
 import PrairieDrawCanvas from "../../components/PrairieDrawCanvas.astro"
 import Row from "../../components/Row.astro"
 import Col from "../../components/Col.astro"
+import CalloutContainer from "../../components/CalloutContainer.astro"
+import CalloutCard from "../../components/CalloutCard.astro"
 ---
 <Layout title = "Trusses" description = "Learn about truss systems, zero force members, the method of joints, and the method of sections.">
 
@@ -57,6 +59,16 @@ In our class, we'll assume that members are <strong>always in tension</strong>. 
 
 
 </p>
+	<CalloutContainer slot = "cards">
+		<CalloutCard title = "Review?">
+			<p>
+				Need a review of <strong>truss assumptions?</strong>
+		 	</p>
+		  	<p>
+				This content has also been explained <a href = "/sta/free_body_diagrams#vector_representation_in_fbds">earlier in the course</a>
+			</p>
+		</CalloutCard>
+	</CalloutContainer>
 </SubSection>
 
 <!-- good summary in lecture 17, slide 5 -->


### PR DESCRIPTION
-adds explanation of assumed vectors and the meaning of the magnitude being found to be negative
-adds heads up and review cards taking users between the FBD page and the reaction forces and trusses page