### PR TITLE
Dynamics link fixes intro->tangent/normal basis

### DIFF
--- a/src/pages/dyn/coordinate_systems.astro
+++ b/src/pages/dyn/coordinate_systems.astro
@@ -469,7 +469,7 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
     </p>
     <p>
       and we substitute in the expression for
-      <InlineEquation equation="\\dot{\\hat{e}_r}" /><a href="#rvs-et">from
+      <InlineEquation equation="\\dot{\\hat{e}_r}" /> <a href="#rvs-et">from
       above</a>. Taking another derivative gives:
     </p>
     <p>

--- a/src/pages/dyn/introduction.astro
+++ b/src/pages/dyn/introduction.astro
@@ -50,10 +50,10 @@ import DisplayTable from "../../components/DisplayTable.astro"
                         <InlineEquation equation = "\\sum \\vec{M} = 0"/>
                     </p>
                 </td>
-                <td>
+                <td style = "vertical-align: middle; border-right: 1px solid var(--bs-border-color);">
                     <a href = "/sta">Statics</a>
                 </td>
-                <td>
+                <td style = "vertical-align: middle;">
                     <a href = "/sol">Solid mechanics</a>
                 </td>
             </tr>

--- a/src/pages/dyn/introduction.astro
+++ b/src/pages/dyn/introduction.astro
@@ -51,10 +51,10 @@ import DisplayTable from "../../components/DisplayTable.astro"
                     </p>
                 </td>
                 <td style = "vertical-align: middle; border-right: 1px solid var(--bs-border-color);">
-                    <a href = "/sta">Statics</a>
+                    <a href = "/sta?origin=sidebar">Statics</a>
                 </td>
                 <td style = "vertical-align: middle;">
-                    <a href = "/sol">Solid mechanics</a>
+                    <a href = "/sol?origin=sidebar">Solid mechanics</a>
                 </td>
             </tr>
             <tr>

--- a/src/pages/dyn/introduction.astro
+++ b/src/pages/dyn/introduction.astro
@@ -51,10 +51,10 @@ import DisplayTable from "../../components/DisplayTable.astro"
                     </p>
                 </td>
                 <td>
-                    <a href = "/sta?origin=sidebar">Statics</a>
+                    <a href = "/sta">Statics</a>
                 </td>
                 <td>
-                    <a href = "/sol?origin=sidebar">Solid mechanics</a>
+                    <a href = "/sol">Solid mechanics</a>
                 </td>
             </tr>
             <tr>
@@ -71,7 +71,7 @@ import DisplayTable from "../../components/DisplayTable.astro"
                 </td>
                 <td>
                     <mark>
-                        <a href = "/dyn?origin=sidebar">Dynamics</a></li>
+                        <a href = "/dyn">Dynamics</a></li>
                     </mark>
                 </td>
                 <td>

--- a/src/pages/dyn/tangential_and_normal_basis.astro
+++ b/src/pages/dyn/tangential_and_normal_basis.astro
@@ -155,7 +155,7 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
 
       Now the basis vector derivatives are given by the cross
       product by <InlineEquation equation="\\vec{\\omega}" /> from <a
-      href="#rkr-ew">#rkr-ew</a>, so we can evaluate
+      href="/dyn/particle_kinematics#rkr-ew">#rkr-ew</a>, so we can evaluate
       the expressions <a href="#rkt-ek">#rkt-ek</a> for
       curvature and torsion to give:
 
@@ -188,7 +188,7 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
     <p>
       We can use the expression <a href="#rkt-ew">#rkt-ew</a>
       for <InlineEquation equation="\\vec{\\omega}" /> together with <a
-      href="#rkr-ew">#rkr-ew</a> to find the basis
+      href="/dyn/particle_kinematics#rkr-ew">#rkr-ew</a> to find the basis
       vector derivatives:
 
       <DisplayEquation equation="\\begin{aligned}\\dot{\\hat{e}}_t &amp;= \\vec{\\omega} \\times \\hat{e}_t= (v\\tau \\,\\hat{e}_t + v \\kappa \\,\\hat{e}_b) \\times \\hat{e}_t= v \\kappa \\,\\hat{e}_n \\\\\\dot{\\hat{e}}_n &amp;= \\vec{\\omega} \\times \\hat{e}_n= (v\\tau \\,\\hat{e}_t + v \\kappa \\,\\hat{e}_b) \\times \\hat{e}_n= - v \\kappa \\,\\hat{e}_t + v \\tau \\,\\hat{e}_b \\\\\\dot{\\hat{e}}_b &amp;= \\vec{\\omega} \\times \\hat{e}_b= (v\\tau \\,\\hat{e}_t + v \\kappa \\,\\hat{e}_b) \\times \\hat{e}_b= -v \\tau \\,\\hat{e}_n.\\end{aligned}" />
@@ -259,7 +259,7 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
 
     <DisplayEquation title="Radius of curvature \\(\\rho\\) for velocity \\(\\vec{v}\\) and acceleration \\(\\vec{a}\\) with angle \\(\\theta\\) between them." id="rkt-er" background="True" derivation="True"  equation="\\rho = \\frac{v^2}{a_n} = \\frac{v^2}{|a\\sin\\theta|}">
       <p>
-        From <a href="#rkt-ev">#rkt-ev</a> we known that the
+        From <a href="#rkt-e">#rkt-e</a> we known that the
         normal component of the acceleration is given by <InlineEquation equation="a_n =\\dot{s}^2/\\rho" /> and from the definition <a
         href="#rkt-es">#rkt-es</a> of path length we have
         <InlineEquation equation="\\dot{s} = v" />, so this equation can be rearranged to
@@ -276,7 +276,7 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
         direction of <InlineEquation equation="\\vec{v}" />, that
         <InlineEquation equation="\\operatorname{Comp}(\\vec{a},\\vec{v})" /> does not depend
         on the magnitude of <InlineEquation equation="\\vec{v}" />, and equation <a
-        href="#rvv-em">#rvv-em</a> for the magnitude of
+        href="/dyn/vectors#rvv-em">#rvv-em</a> for the magnitude of
         the complementary projection.
       </p>
     </DisplayEquation>

--- a/src/pages/dyn/vector_calculus.astro
+++ b/src/pages/dyn/vector_calculus.astro
@@ -148,7 +148,7 @@ import CalloutCard from "../../components/CalloutCard.astro"
 
         The fact that <InlineEquation equation="\\vec{a}^\\perp" /> is a <InlineEquation equation="+90^\\circ" /> rotation
         of <InlineEquation equation="\\vec{a}" /> is apparent from Figure <a
-        href="#rvv-fn-c">#rvv-fn</a>.
+        href="#rvv-fn-c">#rvv-fn-c</a>.
       </p>
     </DisplayEquation>
 

--- a/src/pages/dyn/vector_calculus.astro
+++ b/src/pages/dyn/vector_calculus.astro
@@ -148,7 +148,7 @@ import CalloutCard from "../../components/CalloutCard.astro"
 
         The fact that <InlineEquation equation="\\vec{a}^\\perp" /> is a <InlineEquation equation="+90^\\circ" /> rotation
         of <InlineEquation equation="\\vec{a}" /> is apparent from Figure <a
-        href="#rvv-fn">#rvv-fn</a>.
+        href="#rvv-fn-c">#rvv-fn</a>.
       </p>
     </DisplayEquation>
 

--- a/src/pages/dyn/vectors.astro
+++ b/src/pages/dyn/vectors.astro
@@ -675,14 +675,14 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
     <DisplayEquation title="Derivative of vector direction." background="True" id="rvc-eu" equation="\\dot{\\hat{a}} = \\frac{1}{a}\\operatorname{Comp}(\\dot{\\vec{a}}, \\vec{a})" derivation=True>
       <p>
         We take the definition <a
-        href="/dyn/vector_calculus#rvv-eu">#rvv-eu</a> for the unit vector
+        href="/dyn/vectors#rvv-eu">#rvv-eu</a> for the unit vector
         and differentiate it:
       </p>
       <p>
         <DisplayEquation equation="\\begin{aligned} \\hat{a} &amp;=        \\frac{\\vec{a}}{a} \\\\ \\frac{d}{dt} \\hat{a}        &amp;=        \\frac{d}{dt}\\left(\\frac{\\vec{a}}{a}\\right) \\\\        \\dot{\\hat{a}} &amp;= \\frac{\\dot{\\vec{a}} a -        \\vec{a} \\dot{a}}{a^2} \\\\ &amp;=        \\frac{\\dot{\\vec{a}}}{a} -        \\frac{\\dot{\\vec{a}} \\cdot \\hat{a}}{a^2}        \\vec{a} \\\\ &amp;= \\frac{1}{a} \\big(        \\dot{\\vec{a}} - (\\dot{\\vec{a}} \\cdot        \\hat{a}) \\hat{a} \\big)\\\\ &amp;= \\frac{1}{a}        \\operatorname{Comp}(\\dot{\\vec{a}},        \\vec{a}).\\end{aligned}" />
 
         Here we observed at the end that we had the expression
-        <a href="/dyn/vector_calculus#rvv-em">#rvv-em</a> for the
+        <a href="/dyn/vectors#rvv-em">#rvv-em</a> for the
         complementary projection of the derivative
         <InlineEquation equation="\\dot{\\vec{a}}" /> with respect to <InlineEquation equation="\\vec{a}" />  itself.
       </p>
@@ -699,14 +699,14 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
         From <a href="#rvc-eu">#rvc-eu</a> we know that
         <InlineEquation equation="\\dot{\\hat{a}}" /> is in the direction of <InlineEquation equation="\\operatorname{Comp}(\\dot{\\vec{a}}, \\vec{a})" />
         , and from
-        <a href="/dyn/vector_calculus#rvv-er">#rvv-er</a> we know that this
+        <a href="/dyn/vectors#rvv-er">#rvv-er</a> we know that this
         is orthogonal to <InlineEquation equation="\\vec{a}" /> (and also <InlineEquation equation="\\hat{a}" />).
       </p>
     </DisplayEquation>
 
     <p>
       Recall that we can always write a vector as the <a
-      href="/dyn/vector_calculus#rvv-ei">product of its length and
+      href="/dyn/vectors#rvv-ei">product of its length and
       direction</a>, so <InlineEquation equation="\\vec{a} = a \\hat{a}" />. This gives the
       following decomposition of the derivative of <InlineEquation equation="\\vec{a}" />.
     </p>
@@ -737,7 +737,7 @@ import InlineCanvas from "../../components/InlineCanvas.astro"
           Vector derivatives can be decomposed into length changes
           (projection onto <InlineEquation equation="\\vec{a}" />) and direction changes
           (complementary projection). Compare to Figure <a
-          href="/dyn/vector_calculus#rvv-fu">#rvv-fu</a>.
+          href="/dyn/vectors#rvv-fu-c">#rvv-fu</a>.
         </p>
       </PrairieDrawCanvas>
     </Center>

--- a/src/pages/sta/introduction.astro
+++ b/src/pages/sta/introduction.astro
@@ -16,7 +16,6 @@ import DisplayTable from "../../components/DisplayTable.astro"
 <div slot="navtree">
     <ul class='list-group list-group-flush py-0'> 
         <li class = 'list-group-item py-0'><a class = 'text-decoration-none subsection' href = '#what_is_statics'>What is statics?</a></li>
-        <li class = 'list-group-item py-0'><a class = 'text-decoration-none subsection' href = '#assumptions_in_statics'>Assumptions in statics</a></li>
         <li class='list-group-item py-0'><a class='text-decoration-none subsection' href='#newtons_laws'>Newton's laws</a>
             <ul class='list-group list-group-flush py-0'> 
                 <li class='list-group-item py-0'><a class='text-decoration-none subsubsection' href='#newtons_mass_and_energy_balances'>Newton's first law</a></li> 

--- a/src/pages/sta/introduction.astro
+++ b/src/pages/sta/introduction.astro
@@ -66,11 +66,11 @@ import DisplayTable from "../../components/DisplayTable.astro"
                 </td>
                 <td>
                     <mark>
-                        <a href = "/sta?origin=sidebar">Statics</a>
+                        <a href = "/sta">Statics</a>
                     </mark>
                 </td>
                 <td>
-                    <a href = "/sol?origin=sidebar">Solid mechanics</a>
+                    <a href = "/sol">Solid mechanics</a>
                 </td>
             </tr>
             <tr>
@@ -86,7 +86,7 @@ import DisplayTable from "../../components/DisplayTable.astro"
                     </p>
                 </td>
                 <td>
-                    <a href = "/dyn?origin=sidebar">Dynamics</a></li>
+                    <a href = "/dyn">Dynamics</a></li>
                 </td>
                 <td>
                     Vibration, FEA, robotics, etc.


### PR DESCRIPTION
links that lead to a deleted page:
- The derivation of the equation box "Curvature and torsion. #rkt-ek" has a link trying to reach [this](https://mechref.engr.illinois.edu/dyn/rkt.html#rkt-ea) which is not present in the current pages.
- The derivation of the equation box "Velocity and acceleration in tangential/normal basis. #rkt-e" has a link trying to reach [this](https://mechref.engr.illinois.edu/dyn/rkt.html#rkt-es) which is not present in the current pages.