### PR TITLE
Remove PL tips page

### DIFF
--- a/src/pages/design.astro
+++ b/src/pages/design.astro
@@ -71,7 +71,6 @@ import "../../public/static/css/course_home_pages.css"
   <section class="mt-sm-4 mt-2">
     <h3 class="fw-bold w-100">Helpful links:</h3>
     <ul>
-      <li><a href="/sta/pltips">PrairieLearn tips</a></li>
       <li><a href="/dyn/sympy_tutorial">SymPy tutorial</a></li>
     </ul>
   </section>

--- a/src/pages/dyn.astro
+++ b/src/pages/dyn.astro
@@ -96,7 +96,6 @@ import "../../public/static/css/course_home_pages.css"
   <section class="mt-sm-4 mt-2">
     <h3 class="fw-bold w-100">Helpful links:</h3>
     <ul>
-      <li><a href="/sta/pltips">PrairieLearn tips</a></li>
       <li><a href="/dyn/sympy_tutorial">SymPy tutorial</a></li>
       <li><a href="/about/reference_pages_tutorial">Reference pages tutorial</a></li>
     </ul>

--- a/src/pages/sta.astro
+++ b/src/pages/sta.astro
@@ -87,7 +87,6 @@ import "../../public/static/css/course_home_pages.css"
   <section class="mt-sm-4 mt-2">
     <h3 class="fw-bold w-100">Helpful links:</h3>
     <ul>
-      <li><a href="/sta/pltips">PrairieLearn tips</a></li>
       <li><a href="/about/reference_pages_tutorial">Reference pages tutorial</a></li>
     </ul>
   </section>


### PR DESCRIPTION
Resolves issue #332, which removes the "PrairieLearn Tips" button from all pages, at least in MechRef first. 